### PR TITLE
Migration to Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# python-migration-latest
-This repository contains tests and experiments for migrating code from Python 3.7 to the latest stable Python version. It aims to identify compatibility issues, modernize syntax, and validate dependencies across environments.
+# Project Migration to Python 3.11
+
+## Instructions to Build and Run the Full System
+
+### Step 1: Build and Run the System
+
+Run the following command to build and run the entire system using Docker Compose:
+
+```sh
+docker-compose up --build
+```
+
+### Step 2: Identify Exposed Ports and Services
+
+- Frontend: http://localhost:3000
+- Backend: http://localhost:8000
+
+### Step 3: Verify Frontend and Backend Communication
+
+Open your browser and navigate to the frontend URL (http://localhost:3000). The frontend should successfully call the backend’s `/api/greet/` endpoint.

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,39 @@
+# Backend Service
+
+## Instructions for Building and Running the Backend Container Individually
+
+### Step 1: Build the Backend Container
+
+Run the following command to build the backend container:
+
+```sh
+docker build -t backend-service .
+```
+
+### Step 2: Run the Backend Container
+
+Run the following command to start the backend container:
+
+```sh
+docker run -p 8000:8000 backend-service
+```
+
+## Accessing the /api/greet/ Endpoint
+
+You can access the `/api/greet/` endpoint from a browser or API client (e.g., curl, Postman) using the following URL:
+
+```
+http://localhost:8000/api/greet/
+```
+
+## Accessing the Django Admin Panel
+
+You can access the Django admin panel at the following URL:
+
+```
+http://localhost:8000/admin/
+```
+
+## Verifying Python and Django Versions
+
+The Python and Django versions are displayed on the Django admin login screen (bottom right corner). Open the Django admin panel and check the versions displayed there.

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,3 @@
-Django>=3.2,<3.3
+Django>=4.2,<4.3
 djangorestframework
 django-cors-headers

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,31 @@
+# Frontend Website
+
+## Instructions for Building and Running the Frontend Container Individually
+
+### Step 1: Build the Frontend Container
+
+Run the following command to build the frontend container:
+
+```sh
+docker build -t frontend-website .
+```
+
+### Step 2: Run the Frontend Container
+
+Run the following command to start the frontend container:
+
+```sh
+docker run -p 3000:3000 frontend-website
+```
+
+## Accessing the UI
+
+You can access the UI in a browser using the following URL:
+
+```
+http://localhost:3000
+```
+
+## Verifying Frontend and Backend Communication
+
+To verify that the frontend is communicating correctly with the backend, trigger a test call to the backend API from the frontend. Open the frontend UI and perform an action that calls the backend’s `/api/greet/` endpoint. Ensure that the response is received successfully.


### PR DESCRIPTION
This pull request includes the following changes:

1. Created a new branch named `python-3.6-to-3.11` based on the existing `python-3.6` branch.
2. Updated the `/service/Dockerfile` to use Python 3.11 instead of Python 3.6.
3. Upgraded Django to the latest stable version compatible with Python 3.11 and updated other dependencies in `requirements.txt` as required.
4. Modified the existing `README.md` file at the root of the repository to include instructions for building and running the full system using Docker Compose.
5. Created a `README.md` file inside the `service/` directory with instructions for building and running the backend container individually.
6. Created a `README.md` file inside the `website/` directory with instructions for building and running the frontend container individually.

closes #3