### PR TITLE
Python 3.6 to 3.11 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# python-migration-latest
-This repository contains tests and experiments for migrating code from Python 3.7 to the latest stable Python version. It aims to identify compatibility issues, modernize syntax, and validate dependencies across environments.
+# Full System Setup
+
+## Build and Run
+
+To build and run the full system using Docker Compose, follow these steps:
+
+1. Navigate to the root directory of the repository.
+2. Run the following command to build and start the containers:
+
+```sh
+docker-compose up --build
+```
+
+## Exposed Ports
+
+- Frontend: http://localhost:3000
+- Backend: http://localhost:8000
+
+## Verify Communication
+
+To verify that the frontend and backend can communicate successfully:
+
+1. Open your browser and navigate to the frontend URL: http://localhost:3000
+2. Trigger a test call to the backend API by accessing the following endpoint:
+
+```
+http://localhost:8000/api/greet/
+```
+
+You should see a response from the backend indicating successful communication.

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,33 @@
+# Backend Setup
+
+## Build and Run
+
+To build and run the backend container individually using Docker, follow these steps:
+
+1. Navigate to the `service/` directory.
+2. Run the following command to build and start the container:
+
+```sh
+docker build -t backend-service .
+docker run -p 8000:8000 backend-service
+```
+
+## Accessing the API
+
+To access the `/api/greet/` endpoint from a browser or API client (e.g. curl, Postman), use the following URL:
+
+```
+http://localhost:8000/api/greet/
+```
+
+## Accessing the Django Admin Panel
+
+To access the Django admin panel, use the following URL:
+
+```
+http://localhost:8000/admin/
+```
+
+## Verify Python and Django Version
+
+To verify the Python and Django version displayed on the Django admin login screen, navigate to the admin panel URL and check the bottom right corner of the login screen.

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,3 @@
-Django>=3.2,<3.3
+Django>=4.2,<4.3
 djangorestframework
 django-cors-headers

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,31 @@
+# Frontend Setup
+
+## Build and Run
+
+To build and run the frontend container independently using Docker, follow these steps:
+
+1. Navigate to the `website/` directory.
+2. Run the following command to build and start the container:
+
+```sh
+docker build -t frontend-website .
+docker run -p 3000:3000 frontend-website
+```
+
+## Accessing the UI
+
+To access the UI in a browser, use the following URL:
+
+```
+http://localhost:3000
+```
+
+## Verify Communication with Backend
+
+To verify that the frontend is communicating correctly with the backend, trigger a test call to the backend API by accessing the following endpoint from the frontend application:
+
+```
+http://localhost:8000/api/greet/
+```
+
+You should see a response from the backend indicating successful communication.


### PR DESCRIPTION
This PR includes the following changes:
1. Updated the service Dockerfile to use Python 3.11.
2. Upgraded Django to the latest stable version compatible with Python 3.11 and updated the requirements.txt accordingly.
3. Modified the existing README.md file at the root of the repository with the required instructions.
4. Created a README.md file inside the service/ directory with the specified instructions.
5. Created a README.md file inside the website/ directory with the specified instructions.

closes #<issue_number>