### PR TITLE
Migration to Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # python-migration-latest
 This repository contains tests and experiments for migrating code from Python 3.7 to the latest stable Python version. It aims to identify compatibility issues, modernize syntax, and validate dependencies across environments.
+
+## Instructions to build and run the full system
+
+1. **Build and run the system**:
+    ```sh
+    docker-compose up --build
+    ```
+
+2. **Exposed Ports and Services**:
+    - Frontend: 3000
+    - Backend: 8000
+
+3. **Verify communication between frontend and backend**:
+    - Ensure the frontend can call the backend's `/api/greet/` endpoint successfully.

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,20 @@
+# Backend Service
+
+## Instructions for building and running the backend container individually using Docker
+
+1. **Build and run the backend container**:
+    ```sh
+    docker build -t backend-service .
+    docker run -p 8000:8000 backend-service
+    ```
+
+2. **Access the `/api/greet/` endpoint**:
+    - From a browser: `http://localhost:8000/api/greet/`
+    - Using curl: `curl http://localhost:8000/api/greet/`
+    - Using Postman: Create a new GET request to `http://localhost:8000/api/greet/`
+
+3. **Access the Django admin panel**:
+    - URL: `http://localhost:8000/admin/`
+
+4. **Verify Python and Django version**:
+    - Check the bottom right corner of the Django admin login screen to see the Python and Django version displayed.

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,3 @@
-Django>=3.2,<3.3
+Django>=4.1,<4.2
 djangorestframework
 django-cors-headers

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,15 @@
+# Frontend Website
+
+## Instructions for building and running the frontend container independently using Docker
+
+1. **Build and run the frontend container**:
+    ```sh
+    docker build -t frontend-website .
+    docker run -p 3000:3000 frontend-website
+    ```
+
+2. **Access the UI in a browser**:
+    - URL: `http://localhost:3000`
+
+3. **Verify frontend-backend communication**:
+    - Trigger a test call to the backend API from the frontend and ensure it responds correctly.


### PR DESCRIPTION
This PR migrates the Django backend service from Python 3.6 to Python 3.11. It includes the following changes:

1. Updated the Dockerfile to use Python 3.11-slim.
2. Upgraded Django to version 4.1, compatible with Python 3.11.
3. Updated the root README.md with instructions to build and run the full system using `docker-compose up --build`.
4. Created README.md files in the `service/` and `website/` directories with instructions for building and running the backend and frontend containers individually.

closes #migration