### PR TITLE
Python 3.6 to 3.11 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# python-migration-latest
-This repository contains tests and experiments for migrating code from Python 3.7 to the latest stable Python version. It aims to identify compatibility issues, modernize syntax, and validate dependencies across environments.
+# Project Setup
+
+## Build and Run the Full System
+
+1. Ensure Docker and Docker Compose are installed on your machine.
+2. Navigate to the root directory of the project.
+3. Run the following command to build and start the containers:
+
+```sh
+docker-compose up --build
+```
+
+## Exposed Ports
+
+- Frontend: http://localhost:3000
+- Backend: http://localhost:8000
+
+## Verify Communication
+
+1. Open your browser and navigate to the frontend URL: http://localhost:3000
+2. The frontend should be able to communicate with the backend. You can verify this by triggering a test call to the backend API (e.g., accessing the `/api/greet/` endpoint).

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,24 @@
+# Backend Service
+
+## Build and Run the Backend Container
+
+1. Ensure Docker is installed on your machine.
+2. Navigate to the `service/` directory.
+3. Run the following command to build and start the backend container:
+
+```sh
+docker build -t backend-service .
+docker run -p 8000:8000 backend-service
+```
+
+## Access the API Endpoint
+
+- Open your browser or API client (e.g., curl, Postman) and navigate to: http://localhost:8000/api/greet/
+
+## Access the Django Admin Panel
+
+- Open your browser and navigate to: http://localhost:8000/admin/
+
+## Verify Python and Django Versions
+
+- The Python and Django versions are displayed on the bottom right corner of the Django admin login screen.

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,3 @@
-Django>=3.2,<3.3
+Django>=4.2,<4.3
 djangorestframework
 django-cors-headers

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,20 @@
+# Frontend Website
+
+## Build and Run the Frontend Container
+
+1. Ensure Docker is installed on your machine.
+2. Navigate to the `website/` directory.
+3. Run the following command to build and start the frontend container:
+
+```sh
+docker build -t frontend-website .
+docker run -p 3000:3000 frontend-website
+```
+
+## Access the UI
+
+- Open your browser and navigate to: http://localhost:3000
+
+## Verify Frontend-Backend Communication
+
+- The frontend should be able to communicate with the backend. You can verify this by triggering a test call to the backend API (e.g., accessing the `/api/greet/` endpoint).


### PR DESCRIPTION
This PR migrates the backend service from Python 3.6 to Python 3.11. The following changes have been made:

- Updated the Dockerfile to use Python 3.11-slim.
- Upgraded Django to version 4.2, which is compatible with Python 3.11.
- Updated the requirements.txt file to reflect the new Django version.
- Added README.md files with instructions for building and running the system, as well as verifying communication between frontend and backend.
