### PR TITLE
Python 3.6 to 3.11 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # python-migration-latest
-This repository contains tests and experiments for migrating code from Python 3.7 to the latest stable Python version. It aims to identify compatibility issues, modernize syntax, and validate dependencies across environments.
+
+## Build and Run the Full System
+
+1. Clone the repository:
+```sh
+$ git clone <repository-url>
+$ cd <repository-directory>
+```
+
+2. Checkout the branch `python-3.6-to-3.11`:
+```sh
+$ git checkout python-3.6-to-3.11
+```
+
+3. Build and run the system using Docker Compose:
+```sh
+$ docker-compose up --build
+```
+
+4. The following ports are exposed:
+- Frontend: 3000
+- Backend: 8000
+
+5. Verify communication between frontend and backend:
+- Open the frontend at `http://localhost:3000`
+- Ensure the frontend can call the backend's `/api/greet/` endpoint

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,31 @@
+# Backend Service
+
+## Build and Run the Backend Container Individually
+
+1. Navigate to the `service` directory:
+```sh
+$ cd service
+```
+
+2. Build the Docker image:
+```sh
+$ docker build -t backend-service .
+```
+
+3. Run the Docker container:
+```sh
+$ docker run -p 8000:8000 backend-service
+```
+
+## Access the `/api/greet/` Endpoint
+
+- Open a browser or API client (e.g., curl, Postman)
+- Navigate to `http://localhost:8000/api/greet/`
+
+## Access the Django Admin Panel
+
+- Open a browser and navigate to `http://localhost:8000/admin/`
+
+## Verify Python and Django Versions
+
+- Check the bottom right corner of the Django admin login screen for the Python and Django version information

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,3 @@
-Django>=3.2,<3.3
+Django>=4.1,<4.2
 djangorestframework
 django-cors-headers

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,26 @@
+# Frontend Website
+
+## Build and Run the Frontend Container Individually
+
+1. Navigate to the `website` directory:
+```sh
+$ cd website
+```
+
+2. Build the Docker image:
+```sh
+$ docker build -t frontend-website .
+```
+
+3. Run the Docker container:
+```sh
+$ docker run -p 3000:3000 frontend-website
+```
+
+## Access the UI
+
+- Open a browser and navigate to `http://localhost:3000`
+
+## Verify Frontend-Backend Communication
+
+- Trigger a test call to the backend API from the frontend UI


### PR DESCRIPTION
This PR migrates the backend service from Python 3.6 to Python 3.11. The following changes have been made:

- Updated the Dockerfile to use Python 3.11-slim
- Upgraded Django to a version compatible with Python 3.11
- Updated requirements.txt accordingly
- Added instructions to the root README.md for building and running the full system
- Created a README.md file inside the service/ directory with backend-specific instructions
- Created a README.md file inside the website/ directory with frontend-specific instructions