### PR TITLE
Python 3.6 to 3.11 Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # python-migration-latest
 This repository contains tests and experiments for migrating code from Python 3.7 to the latest stable Python version. It aims to identify compatibility issues, modernize syntax, and validate dependencies across environments.
+
+## Build and Run the Full System
+
+To build and run the full system using Docker Compose, follow these steps:
+
+1. Ensure you have Docker and Docker Compose installed on your machine.
+2. Navigate to the root directory of the repository.
+3. Run the following command to build and start the containers:
+
+```sh
+docker-compose up --build
+```
+
+## Exposed Ports
+
+- Frontend: http://localhost:3000
+- Backend: http://localhost:8000
+
+## Verify Communication
+
+To verify that the frontend and backend can communicate successfully, follow these steps:
+
+1. Open your browser and navigate to the frontend URL: http://localhost:3000
+2. The frontend should make a call to the backend's `/api/greet/` endpoint and display the response.

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,43 @@
+# Backend Service
+
+## Build and Run the Backend Container
+
+To build and run the backend container individually using Docker, follow these steps:
+
+1. Ensure you have Docker installed on your machine.
+2. Navigate to the `service` directory of the repository.
+3. Run the following command to build the container:
+
+```sh
+docker build -t backend-service .
+```
+
+4. Once the build is complete, run the container using the following command:
+
+```sh
+docker run -p 8000:8000 backend-service
+```
+
+## Access the `/api/greet/` Endpoint
+
+You can access the `/api/greet/` endpoint from a browser or API client (e.g., curl, Postman) using the following URL:
+
+```
+http://localhost:8000/api/greet/
+```
+
+## Access the Django Admin Panel
+
+To access the Django admin panel, follow these steps:
+
+1. Open your browser and navigate to the following URL:
+
+```
+http://localhost:8000/admin/
+```
+
+2. Log in using your admin credentials.
+
+## Verify Python and Django Versions
+
+To verify the Python and Django versions displayed on the Django admin login screen, look at the bottom right corner of the login page. The versions should be displayed there.

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,3 +1,3 @@
-Django>=3.2,<3.3
+Django>=4.2,<4.3
 djangorestframework
 django-cors-headers

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,34 @@
+# Frontend Website
+
+## Build and Run the Frontend Container
+
+To build and run the frontend container independently using Docker, follow these steps:
+
+1. Ensure you have Docker installed on your machine.
+2. Navigate to the `website` directory of the repository.
+3. Run the following command to build the container:
+
+```sh
+docker build -t frontend-website .
+```
+
+4. Once the build is complete, run the container using the following command:
+
+```sh
+docker run -p 3000:3000 frontend-website
+```
+
+## Access the UI
+
+You can access the UI in a browser using the following URL:
+
+```
+http://localhost:3000
+```
+
+## Verify Frontend-Backend Communication
+
+To verify that the frontend is communicating correctly with the backend, follow these steps:
+
+1. Open your browser and navigate to the frontend URL: http://localhost:3000
+2. The frontend should make a call to the backend's `/api/greet/` endpoint and display the response.


### PR DESCRIPTION
This PR migrates the Django backend from Python 3.6 to Python 3.11. The following changes have been made:

- Updated the Dockerfile to use Python 3.11-slim.
- Upgraded Django to the latest stable version compatible with Python 3.11.
- Updated requirements.txt to ensure compatibility with Python 3.11 and the upgraded Django version.
- Updated the root README.md file with instructions to build and run the full system using Docker Compose.
- Created a README.md file inside the service/ directory with instructions for building and running the backend container individually.
- Created a README.md file inside the website/ directory with instructions for building and running the frontend container individually.

closes #1